### PR TITLE
Pass Options Dictionary to Plaid API

### DIFF
--- a/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.h
+++ b/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.h
@@ -24,11 +24,9 @@
 
 @property(nonatomic, weak) id<PLDLinkBankMFAContainerViewControllerDelegate> delegate;
 
-- (instancetype)initWithInstitution:(PLDInstitution *)institution
-                            product:(PlaidProduct)product;
+@property(nonatomic, weak) NSDictionary *options;
 
 - (instancetype)initWithInstitution:(PLDInstitution *)institution
-                            product:(PlaidProduct)product
-                            options:(NSMutableDictionary *)options;
+                            product:(PlaidProduct)product;
 
 @end

--- a/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.h
+++ b/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.h
@@ -24,7 +24,7 @@
 
 @property(nonatomic, weak) id<PLDLinkBankMFAContainerViewControllerDelegate> delegate;
 
-@property(nonatomic, weak) NSDictionary *options;
+@property(nonatomic, copy) NSDictionary *options;
 
 - (instancetype)initWithInstitution:(PLDInstitution *)institution
                             product:(PlaidProduct)product;

--- a/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.h
+++ b/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.h
@@ -24,6 +24,11 @@
 
 @property(nonatomic, weak) id<PLDLinkBankMFAContainerViewControllerDelegate> delegate;
 
-- (instancetype)initWithInstitution:(PLDInstitution *)institution product:(PlaidProduct)product;
+- (instancetype)initWithInstitution:(PLDInstitution *)institution
+                            product:(PlaidProduct)product;
+
+- (instancetype)initWithInstitution:(PLDInstitution *)institution
+                            product:(PlaidProduct)product
+                            options:(NSMutableDictionary *)options;
 
 @end

--- a/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.m
+++ b/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.m
@@ -31,25 +31,14 @@ static const CGFloat kKeyboardPadding = 8.0f;
 
   PLDInstitution *_institution;
   PlaidProduct _product;
-  NSMutableDictionary *_options;
 }
 
 - (instancetype)initWithInstitution:(PLDInstitution *)institution product:(PlaidProduct)product {
   if (self = [super init]) {
     _institution = institution;
     _product = product;
-    _options = [NSMutableDictionary new];
   }
   return self;
-}
-
-- (instancetype)initWithInstitution:(PLDInstitution *)institution product:(PlaidProduct)product options:(NSMutableDictionary *)options {
-    if (self = [super init]) {
-        _institution = institution;
-        _product = product;
-        _options = options;
-    }
-    return self;
 }
 
 - (void)loadView {
@@ -70,17 +59,10 @@ static const CGFloat kKeyboardPadding = 8.0f;
   self.navigationItem.backBarButtonItem.target = self;
   self.navigationController.interactivePopGestureRecognizer.delegate = self;
 
-  PLDLinkBankMFALoginViewController *viewController;
-  if (_options) {
-    viewController = [[PLDLinkBankMFALoginViewController alloc]     initWithInstitution:_institution
-        product:_product
-        options:_options];
-  } else {
-      viewController =
-      [[PLDLinkBankMFALoginViewController alloc] initWithInstitution:_institution product:_product];
-  }
+  PLDLinkBankMFALoginViewController *viewController = [[PLDLinkBankMFALoginViewController alloc] initWithInstitution:_institution product:_product];
     
   viewController.delegate = self;
+  viewController.options = _options;
   [self addChildViewController:viewController];
   [_view setCurrentContentView:viewController.view];
   [viewController didMoveToParentViewController:self];

--- a/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.m
+++ b/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.m
@@ -31,14 +31,25 @@ static const CGFloat kKeyboardPadding = 8.0f;
 
   PLDInstitution *_institution;
   PlaidProduct _product;
+  NSMutableDictionary *_options;
 }
 
 - (instancetype)initWithInstitution:(PLDInstitution *)institution product:(PlaidProduct)product {
   if (self = [super init]) {
     _institution = institution;
     _product = product;
+    _options = [NSMutableDictionary new];
   }
   return self;
+}
+
+- (instancetype)initWithInstitution:(PLDInstitution *)institution product:(PlaidProduct)product options:(NSMutableDictionary *)options {
+    if (self = [super init]) {
+        _institution = institution;
+        _product = product;
+        _options = options;
+    }
+    return self;
 }
 
 - (void)loadView {
@@ -59,9 +70,16 @@ static const CGFloat kKeyboardPadding = 8.0f;
   self.navigationItem.backBarButtonItem.target = self;
   self.navigationController.interactivePopGestureRecognizer.delegate = self;
 
-  PLDLinkBankMFALoginViewController *viewController =
-      [[PLDLinkBankMFALoginViewController alloc] initWithInstitution:_institution
-                                                          product:_product];
+  PLDLinkBankMFALoginViewController *viewController;
+  if (_options) {
+    viewController = [[PLDLinkBankMFALoginViewController alloc]     initWithInstitution:_institution
+        product:_product
+        options:_options];
+  } else {
+      viewController =
+      [[PLDLinkBankMFALoginViewController alloc] initWithInstitution:_institution product:_product];
+  }
+    
   viewController.delegate = self;
   [self addChildViewController:viewController];
   [_view setCurrentContentView:viewController.view];

--- a/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.m
+++ b/PlaidLink/Classes/PLDLinkBankMFAContainerViewController.m
@@ -59,7 +59,9 @@ static const CGFloat kKeyboardPadding = 8.0f;
   self.navigationItem.backBarButtonItem.target = self;
   self.navigationController.interactivePopGestureRecognizer.delegate = self;
 
-  PLDLinkBankMFALoginViewController *viewController = [[PLDLinkBankMFALoginViewController alloc] initWithInstitution:_institution product:_product];
+  PLDLinkBankMFALoginViewController *viewController =
+    [[PLDLinkBankMFALoginViewController alloc] initWithInstitution:_institution
+                                                           product:_product];
     
   viewController.delegate = self;
   viewController.options = _options;

--- a/PlaidLink/Classes/PLDLinkBankMFALoginViewController.h
+++ b/PlaidLink/Classes/PLDLinkBankMFALoginViewController.h
@@ -26,5 +26,8 @@
 
 - (instancetype)initWithInstitution:(PLDInstitution *)institution
                             product:(PlaidProduct)product;
+- (instancetype)initWithInstitution:(PLDInstitution *)institution
+                            product:(PlaidProduct)product
+                            options:(NSMutableDictionary *)options;
 
 @end

--- a/PlaidLink/Classes/PLDLinkBankMFALoginViewController.h
+++ b/PlaidLink/Classes/PLDLinkBankMFALoginViewController.h
@@ -24,10 +24,9 @@
 
 @property(nonatomic, weak) id<PLDLinkBankLoginViewControllerDelegate> delegate;
 
+@property(nonatomic, weak) NSDictionary *options;
+
 - (instancetype)initWithInstitution:(PLDInstitution *)institution
                             product:(PlaidProduct)product;
-- (instancetype)initWithInstitution:(PLDInstitution *)institution
-                            product:(PlaidProduct)product
-                            options:(NSMutableDictionary *)options;
 
 @end

--- a/PlaidLink/Classes/PLDLinkBankMFALoginViewController.h
+++ b/PlaidLink/Classes/PLDLinkBankMFALoginViewController.h
@@ -24,7 +24,7 @@
 
 @property(nonatomic, weak) id<PLDLinkBankLoginViewControllerDelegate> delegate;
 
-@property(nonatomic, weak) NSDictionary *options;
+@property(nonatomic, copy) NSDictionary *options;
 
 - (instancetype)initWithInstitution:(PLDInstitution *)institution
                             product:(PlaidProduct)product;

--- a/PlaidLink/Classes/PLDLinkBankMFALoginViewController.m
+++ b/PlaidLink/Classes/PLDLinkBankMFALoginViewController.m
@@ -18,6 +18,7 @@
 @implementation PLDLinkBankMFALoginViewController {
   PLDInstitution *_institution;
   PlaidProduct _product;
+  NSMutableDictionary *_options;
   PLDLinkBankMFALoginView *_view;
 }
 
@@ -26,6 +27,18 @@
   if (self = [super init]) {
     _institution = institution;
     _product = product;
+    _options = [NSMutableDictionary new];
+  }
+  return self;
+}
+
+- (instancetype)initWithInstitution:(PLDInstitution *)institution
+                            product:(PlaidProduct)product
+                            options:(NSMutableDictionary *)options{
+  if (self = [super init]) {
+    _institution = institution;
+    _product = product;
+    _options = options;
   }
   return self;
 }
@@ -54,9 +67,9 @@
 - (void)didTapSubmit {
   [_view.submitButton showLoadingState];
   [self.view endEditing:YES];
-  NSDictionary *options = @{
-      @"list" : @(YES)
-  };
+  
+  _options[@"list"] = @(YES);
+
   __weak PLDLinkBankMFALoginViewController *weakSelf = self;
   __weak PLDLinkBankMFALoginView *weakView = _view;
   [[Plaid sharedInstance] addLinkUserForProduct:_product
@@ -64,7 +77,7 @@
                                        password:_view.passwordTextField.text
                                             pin:_view.pinTextField.text
                                            type:_institution.type
-                                        options:options
+                                        options:_options
                                      completion:^(PLDAuthentication *authentication, id response, NSError *error) {
     if (error && weakSelf) {
       [weakView showErrorWithTitle:[error localizedDescription]

--- a/PlaidLink/Classes/PLDLinkBankMFALoginViewController.m
+++ b/PlaidLink/Classes/PLDLinkBankMFALoginViewController.m
@@ -18,7 +18,6 @@
 @implementation PLDLinkBankMFALoginViewController {
   PLDInstitution *_institution;
   PlaidProduct _product;
-  NSMutableDictionary *_options;
   PLDLinkBankMFALoginView *_view;
 }
 
@@ -27,21 +26,10 @@
   if (self = [super init]) {
     _institution = institution;
     _product = product;
-    _options = [NSMutableDictionary new];
   }
   return self;
 }
 
-- (instancetype)initWithInstitution:(PLDInstitution *)institution
-                            product:(PlaidProduct)product
-                            options:(NSMutableDictionary *)options{
-  if (self = [super init]) {
-    _institution = institution;
-    _product = product;
-    _options = options;
-  }
-  return self;
-}
 
 - (void)loadView {
   _view = [[PLDLinkBankMFALoginView alloc] initWithFrame:CGRectZero
@@ -68,7 +56,9 @@
   [_view.submitButton showLoadingState];
   [self.view endEditing:YES];
   
-  _options[@"list"] = @(YES);
+    
+  NSMutableDictionary* options = [_options mutableCopy];
+  options[@"list"] = @(YES);
 
   __weak PLDLinkBankMFALoginViewController *weakSelf = self;
   __weak PLDLinkBankMFALoginView *weakView = _view;
@@ -77,7 +67,7 @@
                                        password:_view.passwordTextField.text
                                             pin:_view.pinTextField.text
                                            type:_institution.type
-                                        options:_options
+                                        options:options
                                      completion:^(PLDAuthentication *authentication, id response, NSError *error) {
     if (error && weakSelf) {
       [weakView showErrorWithTitle:[error localizedDescription]

--- a/PlaidLink/Classes/PLDLinkBankMFALoginViewController.m
+++ b/PlaidLink/Classes/PLDLinkBankMFALoginViewController.m
@@ -56,8 +56,13 @@
   [_view.submitButton showLoadingState];
   [self.view endEditing:YES];
   
-    
-  NSMutableDictionary* options = [_options mutableCopy];
+  NSMutableDictionary *options;
+  if(_options == nil){
+    options = [[NSMutableDictionary alloc] init];
+  }else {
+    options = [_options mutableCopy];
+  }
+
   options[@"list"] = @(YES);
 
   __weak PLDLinkBankMFALoginViewController *weakSelf = self;

--- a/PlaidLink/Classes/PLDLinkNavigationViewController.h
+++ b/PlaidLink/Classes/PLDLinkNavigationViewController.h
@@ -71,7 +71,7 @@
 @property(nonatomic, readonly) PlaidProduct product;
 
 // Optional Properties
-@property(nonatomic, copy) NSString *webhook;
+@property(nonatomic, weak) NSMutableDictionary *options;
 
 /**
  Create a new PLDLinkNavigationController instance to present the authentication workflow to a user.

--- a/PlaidLink/Classes/PLDLinkNavigationViewController.h
+++ b/PlaidLink/Classes/PLDLinkNavigationViewController.h
@@ -71,7 +71,7 @@
 @property(nonatomic, readonly) PlaidProduct product;
 
 // Optional Properties
-@property(nonatomic, weak) NSDictionary *options;
+@property(nonatomic, copy) NSDictionary *options;
 
 /**
  Create a new PLDLinkNavigationController instance to present the authentication workflow to a user.

--- a/PlaidLink/Classes/PLDLinkNavigationViewController.h
+++ b/PlaidLink/Classes/PLDLinkNavigationViewController.h
@@ -71,7 +71,7 @@
 @property(nonatomic, readonly) PlaidProduct product;
 
 // Optional Properties
-@property(nonatomic, weak) NSMutableDictionary *options;
+@property(nonatomic, weak) NSDictionary *options;
 
 /**
  Create a new PLDLinkNavigationController instance to present the authentication workflow to a user.

--- a/PlaidLink/Classes/PLDLinkNavigationViewController.m
+++ b/PlaidLink/Classes/PLDLinkNavigationViewController.m
@@ -42,7 +42,10 @@
     _animator = [[PLDLinkSelectionToLoginAnimator alloc] init];
 
     self.delegate = self;
-
+    
+    _options = [[NSDictionary alloc] init];
+      
+      
     UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
     _bgBlurView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
     [self.view insertSubview:_bgBlurView atIndex:0];
@@ -66,17 +69,10 @@
 - (void)bankSelectionViewController:(PLDLinkBankSelectionViewController *)viewController
            didFinishWithInstitution:(PLDInstitution *)institution {
     
-  PLDLinkBankMFAContainerViewController *nextViewController;
-  
-  if (self.options) {
-    nextViewController = [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution
-        product:_product
-        options:self.options];
-  } else {
-    nextViewController = [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution
-        product:_product];
-  }
+  PLDLinkBankMFAContainerViewController *nextViewController = [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution product:_product];
+
   nextViewController.delegate = self;
+  nextViewController.options = _options;
   [self pushViewController:nextViewController animated:YES];
 }
 

--- a/PlaidLink/Classes/PLDLinkNavigationViewController.m
+++ b/PlaidLink/Classes/PLDLinkNavigationViewController.m
@@ -65,9 +65,17 @@
 
 - (void)bankSelectionViewController:(PLDLinkBankSelectionViewController *)viewController
            didFinishWithInstitution:(PLDInstitution *)institution {
-  PLDLinkBankMFAContainerViewController *nextViewController =
-      [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution
-                                                                 product:_product];
+    
+  PLDLinkBankMFAContainerViewController *nextViewController;
+  
+  if (self.options) {
+    nextViewController = [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution
+        product:_product
+        options:self.options];
+  } else {
+    nextViewController = [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution
+        product:_product];
+  }
   nextViewController.delegate = self;
   [self pushViewController:nextViewController animated:YES];
 }

--- a/PlaidLink/Classes/PLDLinkNavigationViewController.m
+++ b/PlaidLink/Classes/PLDLinkNavigationViewController.m
@@ -44,8 +44,7 @@
     self.delegate = self;
     
     _options = [[NSDictionary alloc] init];
-      
-      
+    
     UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
     _bgBlurView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
     [self.view insertSubview:_bgBlurView atIndex:0];
@@ -68,8 +67,9 @@
 
 - (void)bankSelectionViewController:(PLDLinkBankSelectionViewController *)viewController
            didFinishWithInstitution:(PLDInstitution *)institution {
-    
-  PLDLinkBankMFAContainerViewController *nextViewController = [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution product:_product];
+  PLDLinkBankMFAContainerViewController *nextViewController =
+    [[PLDLinkBankMFAContainerViewController alloc] initWithInstitution:institution
+                                                               product:_product];
 
   nextViewController.delegate = self;
   nextViewController.options = _options;

--- a/Tests/PlaidLinkTests.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
+++ b/Tests/PlaidLinkTests.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "530709041C03C85A00E296B8"
+               BuildableName = "PlaidLinkTestsUITests.xctest"
+               BlueprintName = "PlaidLinkTestsUITests"
+               ReferencedContainer = "container:PlaidLinkTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/Tests/PlaidLinkTests.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
+++ b/Tests/PlaidLinkTests.xcodeproj/xcshareddata/xcschemes/ios.xcscheme
@@ -28,16 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "530709041C03C85A00E296B8"
-               BuildableName = "PlaidLinkTestsUITests.xctest"
-               BlueprintName = "PlaidLinkTestsUITests"
-               ReferencedContainer = "container:PlaidLinkTests.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
I wanted to pass a `webhook` option to plaid to subscribe to their webhook notifications, but when I looked through your code I realized the webhook variable mentioned in `PLDLinkNavigationViewController.m` wasn't actually implemented in the code.

I decided to change that webhook string to an options dictionary and send all of them to Plaid, which should be more flexible for the future as Plaid continues to develop their API. It works fine although it's a bit cumbersome to pass the options dictionary down the call stack (the code touches 3 different classes), so if you have better ideas on how to implement this I'd be happy to hear them.

Swift usage example:

``` swift
let plaidLink = PLDLinkNavigationViewController(environment: .Tartan, product: .Connect)
plaidLink.linkDelegate = self;
plaidLink.providesPresentationContextTransitionStyle = true
plaidLink.definesPresentationContext = true
plaidLink.modalPresentationStyle = .Custom
plaidLink.options = ["webhook": "https://yourwebsite.com/plaid_webhook"]
self.presentViewController(plaidLink, animated: true, completion: nil)
```
